### PR TITLE
Ensure that xs text is smaller than sm

### DIFF
--- a/lib/src/components/text/Text.stories.tsx
+++ b/lib/src/components/text/Text.stories.tsx
@@ -101,3 +101,12 @@ export const FontWeights = () => (
     <Text weight="bold">Bold</Text>
   </>
 );
+export const Sizes = () => (
+  <>
+    <Text size="xs">xs</Text>
+    <Text size="sm">sm</Text>
+    <Text size="md">md</Text>
+    <Text size="lg">lg</Text>
+    <Text size="xl">xl</Text>
+  </>
+);

--- a/lib/src/components/theme/typography.ts
+++ b/lib/src/components/theme/typography.ts
@@ -14,7 +14,7 @@ export const fontWeight: Record<FontWeight, number> = {
 export const textPreset = {
   1: {
     fontSize: "0.625rem",
-    lineHeight: "1.125rem",
+    lineHeight: "1rem",
     fontWeight: fontWeight.normal,
   },
   2: {

--- a/lib/src/components/theme/typography.ts
+++ b/lib/src/components/theme/typography.ts
@@ -13,7 +13,7 @@ export const fontWeight: Record<FontWeight, number> = {
 
 export const textPreset = {
   1: {
-    fontSize: "0.75rem",
+    fontSize: "0.625rem",
     lineHeight: "1.125rem",
     fontWeight: fontWeight.normal,
   },


### PR DESCRIPTION
## Description
Currently, xs text is the same size as sm. Change it to being .125rem (which is a consistent diff) smaller.

## Test plan
Updated storybook to display font sizes

FIXES PDS-2292