### PR TITLE
Fix flaky storybook tests

### DIFF
--- a/lib/src/components/layout/Layout.stories.tsx
+++ b/lib/src/components/layout/Layout.stories.tsx
@@ -81,7 +81,10 @@ export const LinkButton_ = createStory(Button, {
 export const Callout_ = createStory(Callout, CalloutDefault.args!);
 export const Card_ = createStory(Card, { children: "Test" });
 // @ts-ignore: The Story args type are all marked as optional, but the component has some required props.
-export const Chart_ = createStory(Chart, ScatterLog.args!);
+export const Chart_ = createStory(Chart, {
+  ...ScatterLog.args!,
+  height: "96u",
+});
 // @ts-ignore
 export const Code_ = createStory(Code, JS.args);
 export const DatePicker_ = createStory(DatePicker, {});

--- a/lib/src/components/multiselect/MultiSelect.stories.tsx
+++ b/lib/src/components/multiselect/MultiSelect.stories.tsx
@@ -14,13 +14,16 @@ import { Callout } from "../callout/Callout";
 export default {
   title: "MultiSelect",
   component: MultiSelect,
+  decorators: [
+    (Story) => (
+      <Stack height="96u">
+        <Story />
+      </Stack>
+    ),
+  ],
 } as ComponentMeta<typeof MultiSelect>;
 
-const Template: Story<MultiSelectProps> = (args) => (
-  <Stack height="96u">
-    <MultiSelect {...args} />
-  </Stack>
-);
+const Template: Story<MultiSelectProps> = (args) => <MultiSelect {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/lib/src/components/multiselect/MultiSelect.stories.tsx
+++ b/lib/src/components/multiselect/MultiSelect.stories.tsx
@@ -2,6 +2,7 @@ import { ComponentMeta, Story } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import { useState } from "react";
 
+import { Stack } from "components/stack/Stack";
 import { Text } from "components/text/Text";
 import { MultiSelectState, useComponentState } from "state";
 import { MultiSelectTValue } from "state/components/multiselect/reducer";
@@ -101,6 +102,9 @@ ItemComponent.args = {
 ItemComponent.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
   await userEvent.click(canvas.getByLabelText("Fruits"));
+};
+ItemComponent.parameters = {
+  chromatic: { diffThreshold: 0.83 },
 };
 
 export const ItemComponentDeprecated = Template.bind({});

--- a/lib/src/components/multiselect/MultiSelect.stories.tsx
+++ b/lib/src/components/multiselect/MultiSelect.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, Story } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import { useState } from "react";
 
-import { Stack } from "components/stack/Stack";
+import { Card } from "components/card/Card";
 import { Text } from "components/text/Text";
 import { MultiSelectState, useComponentState } from "state";
 import { MultiSelectTValue } from "state/components/multiselect/reducer";
@@ -16,7 +16,11 @@ export default {
   component: MultiSelect,
 } as ComponentMeta<typeof MultiSelect>;
 
-const Template: Story<MultiSelectProps> = (args) => <MultiSelect {...args} />;
+const Template: Story<MultiSelectProps> = (args) => (
+  <Card height="96u">
+    <MultiSelect {...args} />
+  </Card>
+);
 
 export const Default = Template.bind({});
 Default.args = {

--- a/lib/src/components/multiselect/MultiSelect.stories.tsx
+++ b/lib/src/components/multiselect/MultiSelect.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, Story } from "@storybook/react";
 import { userEvent, within } from "@storybook/testing-library";
 import { useState } from "react";
 
-import { Card } from "components/card/Card";
+import { Stack } from "components/stack/Stack";
 import { Text } from "components/text/Text";
 import { MultiSelectState, useComponentState } from "state";
 import { MultiSelectTValue } from "state/components/multiselect/reducer";
@@ -17,9 +17,9 @@ export default {
 } as ComponentMeta<typeof MultiSelect>;
 
 const Template: Story<MultiSelectProps> = (args) => (
-  <Card height="96u">
+  <Stack height="96u">
     <MultiSelect {...args} />
-  </Card>
+  </Stack>
 );
 
 export const Default = Template.bind({});

--- a/lib/src/components/select/Select.stories.tsx
+++ b/lib/src/components/select/Select.stories.tsx
@@ -3,6 +3,7 @@ import { userEvent, within } from "@storybook/testing-library";
 import { useState } from "react";
 
 import { Callout } from "components/callout/Callout";
+import { Stack } from "components/stack/Stack";
 import { Text } from "components/text/Text";
 import { SelectState, useComponentState } from "state";
 import { SelectTValue } from "state/components/select/reducer";

--- a/lib/src/components/select/Select.stories.tsx
+++ b/lib/src/components/select/Select.stories.tsx
@@ -3,7 +3,7 @@ import { userEvent, within } from "@storybook/testing-library";
 import { useState } from "react";
 
 import { Callout } from "components/callout/Callout";
-import { Card } from "components/card/Card";
+import { Stack } from "components/stack/Stack";
 import { Text } from "components/text/Text";
 import { SelectState, useComponentState } from "state";
 import { SelectTValue } from "state/components/select/reducer";
@@ -17,9 +17,9 @@ export default {
 } as ComponentMeta<typeof Select>;
 
 const Template: Story<SelectProps> = (args) => (
-  <Card height="96u">
+  <Stack height="96u">
     <Select {...args} />
-  </Card>
+  </Stack>
 );
 
 export const Default = Template.bind({});

--- a/lib/src/components/select/Select.stories.tsx
+++ b/lib/src/components/select/Select.stories.tsx
@@ -3,7 +3,7 @@ import { userEvent, within } from "@storybook/testing-library";
 import { useState } from "react";
 
 import { Callout } from "components/callout/Callout";
-import { Stack } from "components/stack/Stack";
+import { Card } from "components/card/Card";
 import { Text } from "components/text/Text";
 import { SelectState, useComponentState } from "state";
 import { SelectTValue } from "state/components/select/reducer";
@@ -16,7 +16,11 @@ export default {
   component: Select,
 } as ComponentMeta<typeof Select>;
 
-const Template: Story<SelectProps> = (args) => <Select {...args} />;
+const Template: Story<SelectProps> = (args) => (
+  <Card height="96u">
+    <Select {...args} />
+  </Card>
+);
 
 export const Default = Template.bind({});
 Default.args = {

--- a/lib/src/components/select/Select.stories.tsx
+++ b/lib/src/components/select/Select.stories.tsx
@@ -14,13 +14,16 @@ import { SelectProps } from "./Select.types";
 export default {
   title: "Select",
   component: Select,
+  decorators: [
+    (Story) => (
+      <Stack height="96u">
+        <Story />
+      </Stack>
+    ),
+  ],
 } as ComponentMeta<typeof Select>;
 
-const Template: Story<SelectProps> = (args) => (
-  <Stack height="96u">
-    <Select {...args} />
-  </Stack>
-);
+const Template: Story<SelectProps> = (args) => <Select {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {

--- a/lib/src/components/table/Table.stories.tsx
+++ b/lib/src/components/table/Table.stories.tsx
@@ -175,7 +175,9 @@ RowActions.args = {
   columns: SIMPLE_DATA_COLUMNS,
   rowActions: ["Delete", "Mark as churned using unnecessarily long button"],
   rowSelection: "single",
-  freezeRowActions: false,
+};
+RowActions.parameters = {
+  chromatic: { diffThreshold: 0.5 },
 };
 
 export const RowActionsMenu = TemplateFn<SimpleUser>().bind({});
@@ -215,6 +217,10 @@ RowActionsLinkButtons.args = {
   ],
   rowSelection: "single",
   freezeRowActions: false,
+};
+RowActionsLinkButtons.parameters = {
+  // Wait for permissions to load
+  chromatic: { delay: 300 },
 };
 
 export const CustomizedRowActions = TemplateFn<SimpleUser>().bind({});


### PR DESCRIPTION
## Description

Make some commonly flaky storybook tests less flaky

* Add a height to select and multiselect to remove the off-by-1 pixel height flakiness
* Bump diffThreshold for flaky RowActions story
* Add a delay to RowActionsLinkButton story so it has some more time to load permissions

## Test plan

Storybooks less flaky