### PR TITLE
Don't show task backed description list loader once info has loaded.

### DIFF
--- a/lib/src/components/descriptionList/DescriptionList.tsx
+++ b/lib/src/components/descriptionList/DescriptionList.tsx
@@ -64,8 +64,8 @@ export const DescriptionListComponent = ({
         >
           {loading ? (
             <>
-              <Skeleton key={idx} height={16} mx={16} width="33%" radius="sm" />
-              <Skeleton key={idx} height={16} mx={16} width="33%" radius="sm" />
+              <Skeleton height={16} mx={16} width="33%" radius="sm" />
+              <Skeleton height={16} mx={16} width="33%" radius="sm" />
             </>
           ) : (
             <>


### PR DESCRIPTION
## Description
Currently the skeleton loader shows even after the description list data has loaded.

## Test plan
I manually tested this and confirmed that the loader only shows up when the data is loading.