### PR TITLE
Remove unused themeContainerDocument and release 2.0.5-rc.1

### DIFF
--- a/examples/adminPanel/package.json
+++ b/examples/adminPanel/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "react": "18.0.0",
     "react-dom": "18.0.0",
-    "@airplane/views": "2.0.5-rc.0"
+    "@airplane/views": "2.0.5-rc.1"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@airplane/views",
   "description": "A React library for building Airplane views. Views components are optimized in style and functionality to produce internal apps that are easy to build and maintain.",
-  "version": "2.0.5-rc.0",
+  "version": "2.0.5-rc.1",
   "license": "MIT",
   "homepage": "https://www.airplane.dev/",
   "repository": {

--- a/lib/src/components/theme/ThemeProvider.tsx
+++ b/lib/src/components/theme/ThemeProvider.tsx
@@ -8,29 +8,10 @@ const emotionCache = createEmotionCache({ key: "airplane" });
 // https://github.com/emotion-js/emotion/issues/1105#issuecomment-557726922
 emotionCache.compat = true;
 
-export const ThemeProvider = ({
-  children,
-  containerDocument = document,
-}: {
-  children: React.ReactNode;
-  containerDocument?: Document;
-}) => {
-  const theme = React.useMemo(() => {
-    if (containerDocument === document) return THEME;
-    const themeCopy = { ...THEME };
-    themeCopy.components = {
-      ...themeCopy.components,
-      Portal: {
-        ...themeCopy.components.Portal,
-        defaultProps: { target: containerDocument.body },
-      },
-    };
-    return themeCopy;
-  }, [containerDocument]);
-
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
   return (
     <MantineProvider
-      theme={theme}
+      theme={THEME}
       withGlobalStyles
       withNormalizeCSS
       emotionCache={emotionCache}

--- a/lib/src/provider/index.tsx
+++ b/lib/src/provider/index.tsx
@@ -34,7 +34,6 @@ const disableQueryConfigRetries = (q: QueryClientConfig | undefined) => {
 export const ViewProvider = ({
   children,
   queryClientConfig,
-  themeContainerDocument,
 }: ViewProviderProps) => {
   React.useEffect(() => {
     const version = getNPMPackageVersion();
@@ -51,7 +50,7 @@ export const ViewProvider = ({
       <QueryClientProvider
         queryClientConfig={disableQueryConfigRetries(queryClientConfig)}
       >
-        <ThemeProvider containerDocument={themeContainerDocument}>
+        <ThemeProvider>
           <NotificationsProvider position="bottom-right">
             <RequestDialogProvider>
               <RunnerScaleSignalProvider>{children}</RunnerScaleSignalProvider>


### PR DESCRIPTION
## Description
themeContainerDocument is no longer used, so we can remove it. This also fixes a ssr issue where document is not defined.
## Test plan
Unit tests pass. Use a local build of the views package in web to verify that views components can be imported