### PR TITLE
Allow boolean default values in task backed form FieldOptions

### DIFF
--- a/lib/src/components/form/Form.stories.tsx
+++ b/lib/src/components/form/Form.stories.tsx
@@ -661,6 +661,7 @@ export const FieldOptions = () => {
         slug: "every_optional_param",
         hiddenFields: ["sql", "file", "number"],
         fieldOptions: [
+          { slug: "boolean", defaultValue: true },
           { slug: "long_text", value: "abc" },
           {
             slug: "short_text",

--- a/lib/src/components/form/Form.types.ts
+++ b/lib/src/components/form/Form.types.ts
@@ -14,7 +14,7 @@ export type FieldOption = {
   /** The value assigned to the field. */
   value?: string | number | boolean | Date;
   /** The default value for the field. Ignored if `value` is set. */
-  defaultValue?: string | number | Date;
+  defaultValue?: string | number | boolean | Date;
   /** The set of allowed values for the field. Ignored if `value` is set. */
   allowedValues?: string[] | number[] | Date[];
   /** If true, the field will be disabled. */

--- a/lib/src/components/form/Form.types.ts
+++ b/lib/src/components/form/Form.types.ts
@@ -15,7 +15,11 @@ export type FieldOption = {
   value?: string | number | boolean | Date;
   /** The default value for the field. Ignored if `value` is set. */
   defaultValue?: string | number | boolean | Date;
-  /** The set of allowed values for the field. Ignored if `value` is set. */
+  /**
+   * The set of allowed values for the field. Ignored if `value` is set. This
+   * prop is only valid if there are at least two allowed values, so boolean
+   * arrays are not supported.
+   */
   allowedValues?: string[] | number[] | Date[];
   /** If true, the field will be disabled. */
   disabled?: boolean;

--- a/lib/src/components/form/parameters.tsx
+++ b/lib/src/components/form/parameters.tsx
@@ -146,7 +146,9 @@ export const parameterToInput = (
     id: idPrefix + param.slug,
     label: param.name,
     key,
-    defaultValue: opt?.defaultValue,
+    ...(param.type === "boolean"
+      ? { defaultChecked: opt?.defaultValue }
+      : { defaultValue: opt?.defaultValue }),
     validate: opt?.validate,
     // This is not param?.desc because we don't want to pass an empty string desc
     description: param.desc || undefined,
@@ -165,7 +167,11 @@ export const parameterToInput = (
       <Select
         clearable
         {...props}
-        defaultValue={canonicalizeValue(opt?.defaultValue, param.type)}
+        defaultValue={
+          typeof opt?.defaultValue === "boolean"
+            ? undefined
+            : canonicalizeValue(opt?.defaultValue, param.type)
+        }
         data={allowedValues}
       />
     );
@@ -175,7 +181,11 @@ export const parameterToInput = (
       <Select
         clearable
         {...props}
-        defaultValue={canonicalizeValue(opt?.defaultValue, param.type)}
+        defaultValue={
+          typeof opt?.defaultValue === "boolean"
+            ? undefined
+            : canonicalizeValue(opt?.defaultValue, param.type)
+        }
         data={constraintValues}
       />
     );


### PR DESCRIPTION
## Description
This change allows checkboxes generated by a task backed form to be configured with the `defaultChecked` property.
## Test plan
tests pass, storybook showing default checked box and other components with defaults set