### PR TITLE
Remove contextual ligatures in views

### DIFF
--- a/examples/adminPanel/index.html
+++ b/examples/adminPanel/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/src/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
     <title>Release cycle</title>
   </head>
   <body>

--- a/lib/src/components/theme/theme.ts
+++ b/lib/src/components/theme/theme.ts
@@ -9,7 +9,11 @@ const borderStyles = {
 };
 
 export const THEME: MantineThemeBase = {
-  globalStyles: () => ({}),
+  globalStyles: () => ({
+    "*": {
+      fontVariantLigatures: "no-contextual",
+    },
+  }),
   dir: "ltr",
   primaryShade: {
     light: 6,


### PR DESCRIPTION
## Description

Remove contextual ligatures from views. Notably, this ensures that the `x` in `5x6` displays as a letter x rather than a multiplication symbol. This makes a view visually consistent with the rest of the Airplane UI.

## Test plan

I also added the inter font stylesheet to our example app so it matches a production view. Without this, I wasn't able to repro the ligature. With this new change, contextual ligatures do not show up.

---
FIXES PDS-2403