### PR TITLE
Add ability to customize the chart axis ranges

### DIFF
--- a/lib/src/components/chart/Chart.stories.tsx
+++ b/lib/src/components/chart/Chart.stories.tsx
@@ -120,6 +120,18 @@ Line.args = {
   },
 };
 
+export const CustomRange = Template.bind({});
+CustomRange.args = {
+  title: "Number of states with a cat older than 100",
+  type: "line",
+  data: {
+    x: ["2022-01-01", "2022-02-01", "2022-03-01", "2022-04-01", "2022-05-01"],
+    states: [10, 15, 45, 29, 16],
+  },
+  xAxisRange: ["2021-12-15", "2022-04-15"],
+  yAxisRange: [0, 60],
+};
+
 export const LineWithPercents = Template.bind({});
 LineWithPercents.args = {
   title: "Percentage",

--- a/lib/src/components/chart/Chart.types.ts
+++ b/lib/src/components/chart/Chart.types.ts
@@ -96,6 +96,7 @@ export type BarProps = {
   mode?: "group" | "stack";
 } & SeriesPlotProps;
 
+export type Range = [unknown, unknown] | "tozero";
 interface SeriesPlotProps {
   /**
    * Which field of `data` to use for the chart's x-axis.
@@ -134,6 +135,15 @@ interface SeriesPlotProps {
    */
   xAxisType?: AxisType;
   /**
+   * A custom range for the x-axis from the first element to the second element.
+   * This can also be set to "tozero" which sets the start of the range to 0 and auto-calculates the end.
+   * If not set, the range is auto-calculated based on the extrema of the input data.
+   * @example [0, 100]
+   * @example ["2016-07-01","2016-12-31"]
+   * @example "tozero"
+   */
+  xAxisRange?: Range;
+  /**
    * Title for the y-axis.
    */
   yAxisTitle?: string;
@@ -146,6 +156,15 @@ interface SeriesPlotProps {
    * @default auto
    */
   yAxisType?: AxisType;
+  /**
+   * A custom range for the y-axis from the first element to the second element.
+   * This can also be set to "tozero" which sets the start of the range to 0 and auto-calculates the end.
+   * If not set, the range is auto-calculated based on the extrema of the input data.
+   * @example [0, 100]
+   * @example ["2016-07-01","2016-12-31"]
+   * @example "tozero"
+   */
+  yAxisRange?: Range;
 }
 
 interface PieProps {

--- a/lib/src/components/chart/buildLayout.test.ts
+++ b/lib/src/components/chart/buildLayout.test.ts
@@ -93,15 +93,19 @@ describe("buildLayout", () => {
       type: "line",
       xAxisType: "linear",
       yAxisType: "log",
+      xAxisRange: "tozero",
+      yAxisRange: [0, 100],
     });
     checkLayout(layout, {
       xaxis: {
         ...BASE_LAYOUT.xaxis,
         type: "linear",
+        rangemode: "tozero",
       },
       yaxis: {
         ...BASE_LAYOUT.yaxis,
         type: "log",
+        range: [0, 100],
       },
     });
   });

--- a/lib/src/components/chart/buildLayout.ts
+++ b/lib/src/components/chart/buildLayout.ts
@@ -1,6 +1,6 @@
 import { Layout } from "plotly.js-basic-dist";
 
-import { AxisType, BarProps, ChartProps } from "./Chart.types";
+import { AxisType, BarProps, ChartProps, Range } from "./Chart.types";
 import { COLORS } from "../theme/colors";
 
 const FONT_FAMILY =
@@ -15,6 +15,8 @@ export const buildLayout = ({
   legendPosition = "right",
   xAxisType = "auto",
   yAxisType = "auto",
+  xAxisRange,
+  yAxisRange,
   ...props
 }: {
   type: ChartProps["type"];
@@ -23,10 +25,12 @@ export const buildLayout = ({
   xAxisTitle?: string;
   xAxisType?: AxisType;
   xAxisFormat?: string;
+  xAxisRange?: Range;
 
   yAxisTitle?: string;
   yAxisType?: AxisType;
   yAxisFormat?: string;
+  yAxisRange?: Range;
   mode?: BarProps["mode"];
 }): Partial<Layout> => {
   const baseLayout: Partial<Layout> = {
@@ -70,6 +74,8 @@ export const buildLayout = ({
           automargin: true,
           fixedrange: true,
           zerolinecolor: "#DEDEDE",
+          range: Array.isArray(xAxisRange) ? xAxisRange : undefined,
+          rangemode: typeof xAxisRange === "string" ? xAxisRange : undefined,
         },
         yaxis: {
           title: yAxisTitle,
@@ -78,6 +84,8 @@ export const buildLayout = ({
           automargin: true,
           fixedrange: true,
           zerolinecolor: "#DEDEDE",
+          range: Array.isArray(yAxisRange) ? yAxisRange : undefined,
+          rangemode: typeof yAxisRange === "string" ? yAxisRange : undefined,
         },
       };
     }


### PR DESCRIPTION
## Description
Add ability to manually customize the x or y axis. You can also opt-in to auto-range while instructing the chart to always start at 0.

You must set  both the min/max, the underlying library does not support setting one but not the other: https://github.com/plotly/plotly.js/issues/400 except for the `tozero` option.

## Test plan
Storybook that tests this functionality
![image](https://user-images.githubusercontent.com/6363419/233652058-9d64a3b0-a0c3-4b37-ab18-7ca8902c99b0.png)

I also added a quick unit test to ensure we are setting the range correctly in plotly.

---

FIXES CAP-2385