### PR TITLE
Reverse text preset and heading preset

### DIFF
--- a/lib/src/@types/mantine-theme.d.ts
+++ b/lib/src/@types/mantine-theme.d.ts
@@ -16,7 +16,7 @@ declare module "@mantine/core" {
   export interface MantineThemeOther {
     typography: {
       textPreset: Record<
-        number,
+        MantineSize,
         {
           fontSize: CSSProperties["fontSize"];
           lineHeight: CSSProperties["lineHeight"];

--- a/lib/src/components/heading/Heading.tsx
+++ b/lib/src/components/heading/Heading.tsx
@@ -42,15 +42,6 @@ export type HeadingProps = {
 } & CommonLayoutProps &
   CommonStylingProps;
 
-const titleOrderToHeadingPreset: Record<HeadingLevel, number> = {
-  1: 6,
-  2: 5,
-  3: 4,
-  4: 3,
-  5: 2,
-  6: 1,
-};
-
 const titleOrderToGrayShade = {
   1: 9,
   2: 8,
@@ -67,7 +58,7 @@ type StyleParams = {
 
 const useStyles = createStyles((theme, { level, weight }: StyleParams) => {
   const headingPreset = {
-    ...theme.other.typography.headingPreset[titleOrderToHeadingPreset[level]],
+    ...theme.other.typography.headingPreset[level],
   };
   if (weight) {
     headingPreset.fontWeight = fontWeight[weight];

--- a/lib/src/components/table/Table.styles.ts
+++ b/lib/src/components/table/Table.styles.ts
@@ -16,7 +16,7 @@ export const useStyles = createStyles((theme) => {
       ".table": {
         overflow: "auto",
         ...theme.fn.fontStyles(),
-        fontSize: theme.other.typography.textPreset[2].fontSize, // NOTE: This seems to be a catch all, I'm not sure if it does anything but matching to be new body size for the table (14px). We can remove this if it's not needed (and maybe even the line above — not sure what that does).
+        fontSize: theme.other.typography.textPreset[4].fontSize, // NOTE: This seems to be a catch all, I'm not sure if it does anything but matching to be new body size for the table (14px). We can remove this if it's not needed (and maybe even the line above — not sure what that does).
         display: "block",
         borderSpacing: 0,
 
@@ -120,7 +120,7 @@ export const useStyles = createStyles((theme) => {
     },
     noData: {
       borderTop: theme.other.borderStyles.light,
-      ...theme.other.typography.textPreset[2],
+      ...theme.other.typography.textPreset[4],
       height: "2.5rem",
       textAlign: "center",
       display: "flex",

--- a/lib/src/components/table/Table.styles.ts
+++ b/lib/src/components/table/Table.styles.ts
@@ -16,7 +16,7 @@ export const useStyles = createStyles((theme) => {
       ".table": {
         overflow: "auto",
         ...theme.fn.fontStyles(),
-        fontSize: theme.other.typography.textPreset[4].fontSize, // NOTE: This seems to be a catch all, I'm not sure if it does anything but matching to be new body size for the table (14px). We can remove this if it's not needed (and maybe even the line above — not sure what that does).
+        fontSize: theme.other.typography.textPreset["sm"].fontSize, // NOTE: This seems to be a catch all, I'm not sure if it does anything but matching to be new body size for the table (14px). We can remove this if it's not needed (and maybe even the line above — not sure what that does).
         display: "block",
         borderSpacing: 0,
 
@@ -120,7 +120,7 @@ export const useStyles = createStyles((theme) => {
     },
     noData: {
       borderTop: theme.other.borderStyles.light,
-      ...theme.other.typography.textPreset[4],
+      ...theme.other.typography.textPreset["sm"],
       height: "2.5rem",
       textAlign: "center",
       display: "flex",

--- a/lib/src/components/tabs/Tabs.styles.ts
+++ b/lib/src/components/tabs/Tabs.styles.ts
@@ -12,7 +12,7 @@ export const useStyles = createStyles((theme, params: StyleParams) => {
     root: { height: "100%" },
     tabIcon: { color: theme.colors.gray[6] },
     tabLabel: {
-      ...theme.other.typography.headingPreset[1],
+      ...theme.other.typography.headingPreset[6],
       lineHeight: "1.5rem",
       color: theme.colors.gray[7],
       marginTop: 0,

--- a/lib/src/components/text/Text.styles.ts
+++ b/lib/src/components/text/Text.styles.ts
@@ -1,13 +1,5 @@
 import { createStyles, MantineSize, useMantineTheme } from "@mantine/core";
 
-const textSizeToTextPreset = {
-  xs: 5,
-  sm: 4,
-  md: 3,
-  lg: 2,
-  xl: 1,
-};
-
 const textSizeToMarginBottom = {
   xs: "0.25rem",
   sm: "0.25rem",
@@ -37,12 +29,8 @@ export const useRawTextStyles = createStyles(
   (theme, { size }: { size: MantineSize }) => {
     return {
       root: {
-        fontSize:
-          theme.other.typography.textPreset[textSizeToTextPreset[size]]
-            .fontSize,
-        lineHeight:
-          theme.other.typography.textPreset[textSizeToTextPreset[size]]
-            .lineHeight,
+        fontSize: theme.other.typography.textPreset[size].fontSize,
+        lineHeight: theme.other.typography.textPreset[size].lineHeight,
       },
     };
   }
@@ -50,6 +38,5 @@ export const useRawTextStyles = createStyles(
 
 export const useTextWeight = (size: MantineSize) => {
   const theme = useMantineTheme();
-  return theme.other.typography.textPreset[textSizeToTextPreset[size]]
-    .fontWeight;
+  return theme.other.typography.textPreset[size].fontWeight;
 };

--- a/lib/src/components/text/Text.styles.ts
+++ b/lib/src/components/text/Text.styles.ts
@@ -1,11 +1,11 @@
 import { createStyles, MantineSize, useMantineTheme } from "@mantine/core";
 
 const textSizeToTextPreset = {
-  xs: 1,
-  sm: 2,
+  xs: 5,
+  sm: 4,
   md: 3,
-  lg: 4,
-  xl: 5,
+  lg: 2,
+  xl: 1,
 };
 
 const textSizeToMarginBottom = {

--- a/lib/src/components/theme/theme.ts
+++ b/lib/src/components/theme/theme.ts
@@ -117,7 +117,7 @@ export const THEME: MantineThemeBase = {
     InputWrapper: {
       styles: (theme) => ({
         label: {
-          ...headingPreset[1],
+          ...headingPreset[6],
           color: theme.colors.gray[7],
           marginBottom: "0.375rem",
         },

--- a/lib/src/components/theme/theme.ts
+++ b/lib/src/components/theme/theme.ts
@@ -123,14 +123,14 @@ export const THEME: MantineThemeBase = {
         },
 
         description: {
-          ...textPreset[3],
+          ...textPreset["md"],
           color: theme.colors.gray[6],
           marginTop: "0.25rem",
           marginBottom: 0,
         },
 
         error: {
-          ...textPreset[3],
+          ...textPreset["md"],
           whiteSpace: "pre-wrap",
         },
       }),
@@ -174,7 +174,7 @@ export const THEME: MantineThemeBase = {
     Tooltip: {
       styles: (theme) => ({
         tooltip: {
-          ...textPreset[4],
+          ...textPreset["sm"],
           padding: "6px 10px",
           borderRadius: theme.radius.md,
           color: "white",
@@ -184,13 +184,13 @@ export const THEME: MantineThemeBase = {
     Notification: {
       styles: (theme, props: NotificationStylesParams) => {
         const topLine = {
-          ...textPreset[3],
+          ...textPreset["md"],
           color: theme.colors.gray[9],
           marginBottom: 0,
           fontWeight: 500,
         };
         const bottomLine = {
-          ...textPreset[3],
+          ...textPreset["md"],
           color: theme.colors.gray[5],
           marginBottom: 0,
           marginTop: theme.spacing.xs,

--- a/lib/src/components/theme/theme.ts
+++ b/lib/src/components/theme/theme.ts
@@ -174,7 +174,7 @@ export const THEME: MantineThemeBase = {
     Tooltip: {
       styles: (theme) => ({
         tooltip: {
-          ...textPreset[2],
+          ...textPreset[4],
           padding: "6px 10px",
           borderRadius: theme.radius.md,
           color: "white",

--- a/lib/src/components/theme/typography.ts
+++ b/lib/src/components/theme/typography.ts
@@ -12,12 +12,12 @@ export const fontWeight: Record<FontWeight, number> = {
 };
 
 export const textPreset = {
-  1: {
+  5: {
     fontSize: "0.625rem",
     lineHeight: "1rem",
     fontWeight: fontWeight.normal,
   },
-  2: {
+  4: {
     fontSize: "0.75rem",
     lineHeight: "1.125rem",
     fontWeight: fontWeight.normal,
@@ -27,12 +27,12 @@ export const textPreset = {
     lineHeight: "1.25rem",
     fontWeight: fontWeight.normal,
   },
-  4: {
+  2: {
     fontSize: "1rem",
     lineHeight: "1.375rem",
     fontWeight: fontWeight.normal,
   },
-  5: {
+  1: {
     fontSize: "1.125rem",
     lineHeight: "1.5rem",
     fontWeight: fontWeight.normal,
@@ -40,19 +40,19 @@ export const textPreset = {
 };
 
 export const headingPreset = {
-  1: {
+  6: {
     fontSize: "0.875rem",
     lineHeight: "1rem",
     fontWeight: fontWeight.medium,
     marginTop: "0.25rem",
   },
-  2: {
+  5: {
     fontSize: "1rem",
     lineHeight: "1.25rem",
     fontWeight: fontWeight.semibold,
     marginTop: "0.125rem",
   },
-  3: {
+  4: {
     fontSize: "1.166rem",
     lineHeight: "1.25rem",
     fontWeight: fontWeight.semibold,
@@ -60,7 +60,7 @@ export const headingPreset = {
     marginTop: "0.125rem",
     marginBottom: "0.25rem",
   },
-  4: {
+  3: {
     fontSize: "1.333rem",
     lineHeight: "1.5rem",
     fontWeight: fontWeight.bold,
@@ -68,7 +68,7 @@ export const headingPreset = {
     marginBottom: "0.5rem",
     marginTop: "1rem",
   },
-  5: {
+  2: {
     fontSize: "1.555rem",
     lineHeight: "1.75rem",
     fontWeight: fontWeight.bold,
@@ -76,7 +76,7 @@ export const headingPreset = {
     marginBottom: "0.75rem",
     marginTop: "1.25rem",
   },
-  6: {
+  1: {
     fontSize: "1.777rem",
     lineHeight: "2rem",
     fontWeight: fontWeight.bold,

--- a/lib/src/components/theme/typography.ts
+++ b/lib/src/components/theme/typography.ts
@@ -12,27 +12,27 @@ export const fontWeight: Record<FontWeight, number> = {
 };
 
 export const textPreset = {
-  5: {
+  xs: {
     fontSize: "0.625rem",
     lineHeight: "1rem",
     fontWeight: fontWeight.normal,
   },
-  4: {
+  sm: {
     fontSize: "0.75rem",
     lineHeight: "1.125rem",
     fontWeight: fontWeight.normal,
   },
-  3: {
+  md: {
     fontSize: "0.875rem",
     lineHeight: "1.25rem",
     fontWeight: fontWeight.normal,
   },
-  2: {
+  lg: {
     fontSize: "1rem",
     lineHeight: "1.375rem",
     fontWeight: fontWeight.normal,
   },
-  1: {
+  xl: {
     fontSize: "1.125rem",
     lineHeight: "1.5rem",
     fontWeight: fontWeight.normal,

--- a/lib/src/components/title/Title.tsx
+++ b/lib/src/components/title/Title.tsx
@@ -50,15 +50,6 @@ export type TitleProps = {
 } & CommonLayoutProps &
   CommonStylingProps;
 
-const titleOrderToHeadingPreset: Record<TitleOrder, number> = {
-  1: 6,
-  2: 5,
-  3: 4,
-  4: 3,
-  5: 2,
-  6: 1,
-};
-
 const titleOrderToGrayShade = {
   1: 9,
   2: 8,
@@ -74,7 +65,7 @@ type StyleParams = {
 
 const useStyles = createStyles((theme, { order }: StyleParams) => ({
   root: {
-    ...theme.other.typography.headingPreset[titleOrderToHeadingPreset[order]],
+    ...theme.other.typography.headingPreset[order],
     "&:first-child": {
       marginTop: 0,
     },


### PR DESCRIPTION
## Description
Line up the heading and text presets with heading order, i.e. the smallest number is the largest.

As we currently have it, we're passing in a reversed (incorrect) list as the `headings` theme. We could reverse it in `theme.ts`, but I think it's easier to do what I did here.

## Test plan
I'm relying on chromatic to point out any UI diffs

fixes https://github.com/airplanedev/views/issues/45