### PR TITLE
Grow chart to 100% of container

### DIFF
--- a/lib/src/components/chart/Chart.stories.tsx
+++ b/lib/src/components/chart/Chart.stories.tsx
@@ -209,7 +209,7 @@ export const Loading = () => {
 
 export const NextToEachOther = () => {
   return (
-    <Stack>
+    <Stack direction="row">
       <Chart
         id="chart"
         type="scatter"

--- a/lib/src/components/chart/Chart.stories.tsx
+++ b/lib/src/components/chart/Chart.stories.tsx
@@ -206,3 +206,28 @@ export const Loading = () => {
     />
   );
 };
+
+export const NextToEachOther = () => {
+  return (
+    <Stack>
+      <Chart
+        id="chart"
+        type="scatter"
+        data={[
+          { x: 0, square: 0 },
+          { x: 1, square: 1 },
+          { x: 2, square: 4 },
+        ]}
+      />
+      <Chart
+        id="chart"
+        type="scatter"
+        data={[
+          { x: 0, square: 0 },
+          { x: 1, square: 1 },
+          { x: 2, square: 4 },
+        ]}
+      />
+    </Stack>
+  );
+};

--- a/lib/src/components/chart/ChartComponent.tsx
+++ b/lib/src/components/chart/ChartComponent.tsx
@@ -32,10 +32,9 @@ const useStyles = createStyles(
     wrapper: {
       display: "flex",
       flexDirection: "column",
+      alignItems: "center",
       rowGap: "0.5rem",
-    },
-    title: {
-      alignSelf: "center",
+      width: "100%",
     },
     plot: {
       width: "100%",
@@ -91,11 +90,7 @@ const ChartComponent = ({
     <div style={style} className={cx(classes.wrapper, layoutClasses.style)}>
       {
         // Render title using our own component, instead of Plotly's.
-        title ? (
-          <Heading className={classes.title} level={2}>
-            {title}
-          </Heading>
-        ) : null
+        title ? <Heading level={2}>{title}</Heading> : null
       }
       {loading && (
         <div className={classes.loadingContainer}>


### PR DESCRIPTION
## Description
Grow chart to fill 100% of container. This is similar to how table works where it will fill as much space as it needs and shrink down as appropriate.

If I place two charts next to each other in a stack
Before
![image](https://github.com/airplanedev/views/assets/6363419/1f9661be-0816-41a4-b1fe-d1021eef6932)
After
![image](https://github.com/airplanedev/views/assets/6363419/caba19c6-7797-4e05-8cd3-e791bed494b8)

One chart in a stack
Before
![image](https://github.com/airplanedev/views/assets/6363419/a39f83be-cd36-4932-a7f3-d574c3796d17)
After
![image](https://github.com/airplanedev/views/assets/6363419/dc0d6385-396e-45d8-b15a-fbf836c8d160)


## Test plan
I played around with a bunch of chart examples