### PR TITLE
Explicitly set chart height

### DIFF
--- a/examples/adminPanel/package.json
+++ b/examples/adminPanel/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "react": "18.0.0",
     "react-dom": "18.0.0",
-    "@airplane/views": "2.1.0-rc.2"
+    "@airplane/views": "2.1.0-rc.4"
   },
   "devDependencies": {
     "@types/react": "^18.0.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@airplane/views",
   "description": "A React library for building Airplane views. Views components are optimized in style and functionality to produce internal apps that are easy to build and maintain.",
-  "version": "2.1.0-rc.3",
+  "version": "2.1.0-rc.4",
   "license": "MIT",
   "homepage": "https://www.airplane.dev/",
   "repository": {

--- a/lib/src/components/chart/Chart.stories.tsx
+++ b/lib/src/components/chart/Chart.stories.tsx
@@ -231,3 +231,17 @@ export const NextToEachOther = () => {
     </Stack>
   );
 };
+
+export const WithHeight = Template.bind({});
+WithHeight.args = {
+  title: "My scatter chart",
+  type: "scatter",
+  data: [
+    { x: 0, square: 0, cube: 0 },
+    { x: 1, square: 1, cube: 1 },
+    { x: 2, square: 4, cube: 9 },
+    { x: 3, square: 9, cube: 27 },
+    { x: 4, square: 16, cube: 64 },
+  ],
+  height: "1000px",
+};

--- a/lib/src/components/chart/ChartComponent.tsx
+++ b/lib/src/components/chart/ChartComponent.tsx
@@ -17,7 +17,7 @@ type ChartComponentProps = ChartProps & {
   onSelected?: (event: Plotly.PlotSelectionEvent) => void;
   onDeselect?: () => void;
 };
-const DEFAULT_HEIGHT = "375px";
+const DEFAULT_HEIGHT = "384px";
 
 const useStyles = createStyles(
   (

--- a/lib/src/components/chart/ChartComponent.tsx
+++ b/lib/src/components/chart/ChartComponent.tsx
@@ -17,6 +17,7 @@ type ChartComponentProps = ChartProps & {
   onSelected?: (event: Plotly.PlotSelectionEvent) => void;
   onDeselect?: () => void;
 };
+const DEFAULT_HEIGHT = "375px";
 
 const useStyles = createStyles(
   (
@@ -48,14 +49,14 @@ const useStyles = createStyles(
       width: width != null ? "100%" : 500,
       height: "100%",
       // If the container's height is not set, use a fixed height.
-      minHeight: height != null ? undefined : 200,
+      minHeight: height != null ? undefined : DEFAULT_HEIGHT,
     },
     errorLabel: {
       // If the container's width/height is set, fill it. If not, use a fixed width/height.
       width: width != null ? "100%" : 500,
       height: "100%",
       // If the container's height is not set, use a fixed height.
-      minHeight: height != null ? undefined : 200,
+      minHeight: height != null ? undefined : DEFAULT_HEIGHT,
     },
   })
 );
@@ -71,7 +72,7 @@ const ChartComponent = ({
   className,
   style,
   width,
-  height,
+  height = DEFAULT_HEIGHT,
   grow,
   loading,
   error,


### PR DESCRIPTION
## Description

Explicitly set chart height rather than relying on the height set by the underlying library.

We thought that the library might be setting the height intelligently based on the data, but it's actually just hardcoding it to 450px. We'd rather control the height so we can decide what the ideal height is (375 seemed a bit better to view the data and view multiple charts on the same page) and use this height for our loading and error states.

## Test plan
Our chart storybooks will update and I added a new storybook to confirm that you can customize the height.