### PR TITLE
Fix task-backed forms not showing option labels

### DIFF
--- a/lib/src/components/form/Form.stories.tsx
+++ b/lib/src/components/form/Form.stories.tsx
@@ -392,15 +392,15 @@ const mockData = [
                 optional: true,
                 options: [
                   {
-                    label: "",
+                    label: "Cat",
                     value: "cat",
                   },
                   {
-                    label: "",
+                    label: "Dog",
                     value: "dog",
                   },
                   {
-                    label: "",
+                    label: "Fish",
                     value: "fish",
                   },
                 ],

--- a/lib/src/components/form/parameters.tsx
+++ b/lib/src/components/form/parameters.tsx
@@ -176,7 +176,10 @@ export const parameterToInput = (
       />
     );
   } else if (param.constraints.options) {
-    const constraintValues = param.constraints.options.map((v) => v.value);
+    const constraintOptions = param.constraints.options.map((v) => ({
+      label: v.label || v.value, // Override not set or empty ("") label
+      value: v.value,
+    }));
     return (
       <Select
         clearable
@@ -186,7 +189,7 @@ export const parameterToInput = (
             ? undefined
             : canonicalizeValue(opt?.defaultValue, param.type)
         }
-        data={constraintValues}
+        data={constraintOptions}
       />
     );
   }


### PR DESCRIPTION
## Description

`Select`s in task-backed forms don't show `label`s for options, even if a label is provided. This was because we were only passing options with `value`s to the `Select`

## Test plan

Take a look at the first (short text) input in the `form--with-task` story and confirm that the `Select` now shows the upper-case animal name labels (not the lower-case values)