### PR TITLE
Fix form submissions not including single files

### DIFF
--- a/lib/src/components/form/Form.tsx
+++ b/lib/src/components/form/Form.tsx
@@ -221,7 +221,7 @@ const FormWithRunnable = <TOutput,>({
         // Extract the first element of file inputs
         .map(([key, val]) => {
           if (paramMetadata[key] === "upload") {
-            return [key, val?.length ? val[0] : undefined];
+            return [key, val?.length ? val[0] : val];
           } else {
             return [key, val];
           }


### PR DESCRIPTION
## Description

If a `FileInput` submits only a single file to a `Form` in order to run a task, the form would ignore it and return `undefined` for the parameter instead. This was affecting both task-backed forms with `upload` parameters and normal `FileInput` components.

## Test plan

Create a task-backed Form for a task with a required `upload` parameter. Confirm that the upload parameter isn't submitted to the task before this change, but is correctly sent with this change.
